### PR TITLE
Update auth pages to show API error messages

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 
 interface LoginApiResponse {
   success: boolean;
+  message?: string;
   error?: string;
   token?: string;
   user?: any;
@@ -40,7 +41,7 @@ export default function LoginPage() {
                 // Перенаправление на дашборд
                 router.push('/dashboard');
             } else {
-                setMessage(`❌ Ошибка: ${data.error || 'Что-то пошло не так'}`);
+                setMessage(`❌ Ошибка: ${data.message || data.error || 'Что-то пошло не так'}`);
             }
         } catch (error) {
             setMessage('❌ Ошибка: Не удалось выполнить запрос');

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -27,7 +27,7 @@ export default function RegisterPage() {
         if (res.ok) {
             setMessage('✅ Регистрация успешна!');
         } else {
-            setMessage(`❌ Ошибка: ${data.error || 'Что-то пошло не так'}`);
+            setMessage(`❌ Ошибка: ${data.message || data.error || 'Что-то пошло не так'}`);
         }
     };
 


### PR DESCRIPTION
## Summary
- show `data.message` if provided for login and register errors
- add `message` property to `LoginApiResponse`

## Testing
- `npm run build` *(fails: Failed to fetch `Geist` font from Google Fonts)*
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684946939780832e9b0651fe313c940f