### PR TITLE
Fix logout token clearing

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -5,7 +5,7 @@ import { clearAuthCookie } from '@/lib/auth';
 export async function POST(request: NextRequest) {
   try {
     // Очистка куки с токеном аутентификации
-    clearAuthCookie();
+    await clearAuthCookie();
     
     return NextResponse.json({
       success: true,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -66,19 +66,9 @@ export async function setAuthCookie(token: string): Promise<void> {
   });
 }
 
-export function clearAuthCookie() {
-  // Возвращает пустой куки (по твоей логике)
-  return {
-    name: 'token',
-    value: '',
-    options: {
-      httpOnly: true,
-      secure: true,
-      path: '/',
-      sameSite: 'strict',
-      maxAge: 0,
-    }
-  };
+export async function clearAuthCookie(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(AUTH_COOKIE_NAME);
 }
 
 export async function getCurrentUser(): Promise<any | null> {


### PR DESCRIPTION
## Summary
- delete auth token using the `cookies()` API
- await cookie clear in logout route so Set-Cookie header is applied

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849506cdd98832e983efbd81fddc03f