### PR TITLE
Clarify database env vars and migrations

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,6 @@
 # Данные подключения к базе
+# Для PostgreSQL используйте POSTGRES_URL, например:
+# POSTGRES_URL=postgres://user:password@localhost:5432/artel
 DATABASE_URL=sqlite:./znk_artel.db
 # Секретный ключ для JWT
 JWT_SECRET=supersecretkey

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,5 @@
 DB_MOCK=false
 NODE_ENV=production
+# DATABASE_URL используется для SQLite или Cloudflare D1
+# Для PostgreSQL задайте POSTGRES_URL в окружении
 DATABASE_URL=sqlite:./znk_artel.db

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@
 
 3.  **Настройте переменные окружения:**
     Создайте файл `.env.local` и заполните его необходимыми значениями (см. `.env.example`, если он есть):
-    *   `DATABASE_URL`: Строка подключения к базе данных.
+   *   `POSTGRES_URL` (или единый `DATABASE_URL`): строка подключения к PostgreSQL,
+       например `postgres://user:password@localhost:5432/artel`.
     *   `JWT_SECRET`: Секретный ключ для JWT.
     *   `BLOCKCHAIN_RPC_URL`: URL RPC-узла блокчейна.
     *   `ADMIN_PRIVATE_KEY`: Приватный ключ кошелька администратора.
@@ -58,7 +59,7 @@
     *   ...
 
 4.  **Примените миграции базы данных:**
-    *   Для Cloudflare D1 (если используется):
+    *   **Cloudflare D1:**
         ```bash
         # Установите wrangler: npm install -g wrangler
         # Сброс (если нужно): rm -rf .wrangler/state/v3
@@ -66,10 +67,9 @@
         # Или для применения новых миграций:
         # wrangler d1 migrations apply DB --local
         ```
-    *   Для PostgreSQL (если используется Prisma или другой ORM):
-        ```bash
-        npx prisma migrate dev
-        ```
+    *   **PostgreSQL:** запустите SQL-файлы из папки `migrations` командой
+        `psql $POSTGRES_URL -f migrations/0001_initial.sql` или используйте
+        подходящий инструмент миграций.
 
 5.  **Запустите сервер разработки:**
     ```bash

--- a/src/lib/db-neon.ts
+++ b/src/lib/db-neon.ts
@@ -1,7 +1,7 @@
 import { Pool } from 'pg';
 
 const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
+  connectionString: process.env.POSTGRES_URL || process.env.DATABASE_URL,
   ssl: {
     rejectUnauthorized: false
   }


### PR DESCRIPTION
## Summary
- document that `POSTGRES_URL`/`DATABASE_URL` holds the PostgreSQL connection string
- explain how to run migrations for PostgreSQL using `psql`
- allow `db-neon.ts` to read either env variable
- add example values in `.env` files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684953bf1b48832eb72ea0d0e9ec3843