### PR TITLE
Use DATABASE_URL for neon connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 3.  **Настройте переменные окружения:**
     Создайте файл `.env.local` и заполните его необходимыми значениями (см. `.env.example`, если он есть):
-    *   `DATABASE_URL`: Строка подключения к базе данных.
+    *   `DATABASE_URL`: Строка подключения к базе данных. Например для PostgreSQL: `postgresql://user:password@host:5432/dbname`
     *   `JWT_SECRET`: Секретный ключ для JWT.
     *   `BLOCKCHAIN_RPC_URL`: URL RPC-узла блокчейна.
     *   `ADMIN_PRIVATE_KEY`: Приватный ключ кошелька администратора.

--- a/src/lib/db-neon.ts
+++ b/src/lib/db-neon.ts
@@ -1,7 +1,7 @@
 import { Pool } from 'pg';
 
 const pool = new Pool({
-  connectionString: process.env.POSTGRES_URL,
+  connectionString: process.env.DATABASE_URL,
   ssl: {
     rejectUnauthorized: false
   }


### PR DESCRIPTION
## Summary
- update README env var example
- switch POSTGRES_URL to DATABASE_URL in db-neon

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6849569cdd40832eabeb0e04a9d58a9d