### PR TITLE
Fix comment about password hashing

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,7 +9,7 @@ const JWT_SECRET = new TextEncoder().encode(process.env.JWT_SECRET || 'znk-artel
 const TOKEN_EXPIRATION_SECONDS = 60 * 60 * 24 * 7; // 7 days
 const AUTH_COOKIE_NAME = 'auth_token';
 
-// --- Password Hashing (SHA-256, not bcrypt) ---
+// --- Password Hashing using bcrypt ---
 export async function hashPassword(password: string): Promise<string> {
   try {
     return await bcrypt.hash(password, BCRYPT_ROUNDS);


### PR DESCRIPTION
## Summary
- fix comment on password hashing in auth util

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495a33a948832eaaaa676d1e486800